### PR TITLE
add filename parameter to upload function

### DIFF
--- a/sypht/client.py
+++ b/sypht/client.py
@@ -166,11 +166,14 @@ class SyphtClient(object):
         endpoint=None,
         workflow=None,
         options=None,
+        filename=None,
         headers=None,
     ):
         endpoint = urljoin(endpoint or self.base_endpoint, "fileupload")
         headers = headers or {}
         headers = self._get_headers(**headers)
+        if filename is not None:
+            file = (filename, file)
         files = {"fileToUpload": file}
 
         if isinstance(fieldsets, six.string_types):


### PR DESCRIPTION
Noticed that the client doesn't include the filename on the request (after a sytest run).  I've added an optional parameter to the login function to resolve this.

I don't have a test harness for this so please test this before merging.