### PR TITLE
chore(cli): improve error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ print(sc.fetch_results(fid))
 or run it via the command line:
 
 ```
-$ sypht extract --product invoices path/to/your/document.pdf
+export SYPHT_API_KEY="<client_id>:<client_secret>"
+sypht extract --product invoices path/to/your/document.pdf
 ```
 
 ## Documentation

--- a/sypht/client.py
+++ b/sypht/client.py
@@ -49,13 +49,15 @@ class SyphtClient(object):
             if not env_key:
                 raise ValueError(
                     "Missing API key configuration. Add "
-                    + self.API_ENV_KEY
-                    + " to the environment or "
+                    + f'{self.API_ENV_KEY}="<client_id>:<client_secret>" to the environment or '
                     + "directly pass client_id and client_secret parameters to the client constructor."
                 )
             elif env_key and len(key_parts) != 2:
                 raise ValueError(
-                    "Invalid " + self.API_ENV_KEY + " environment variable configured"
+                    f"Invalid {self.API_ENV_KEY} environment variable configured. " +
+                    "<client_id> and <client_secret> must be provided as a single, " +
+                    "colon-separated environment variable, i.e: " +
+                    f'export {self.API_ENV_KEY}="<client_id>:<client_secret>"'
                 )
             client_id, client_secret = key_parts
 


### PR DESCRIPTION
`README.md` doesn't specify correct formatting for environment variables, which currently needs to be deduced by reading the package source code. This PR adds this information to both `README.md` and error messaging to improve user experience.