### PR TITLE
Added get and set functions for external validation rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.5.12"
+__version__ = "0.5.13"
 __pkg_name__ = "sypht"
 
 setup(

--- a/sypht/client.py
+++ b/sypht/client.py
@@ -233,6 +233,31 @@ class SyphtClient:
             )
         )
 
+    def get_validation_rules(self, company_id=None, rules_id=None, endpoint=None):
+        company_id = company_id or self.company_id
+        endpoint = urljoin(
+            endpoint or self.base_endpoint,
+            f"workflows/rules/{company_id}/{rules_id}",
+        )
+        headers = self._get_headers()
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        return self._parse_response(self.requests.get(endpoint, headers=headers))
+
+    def set_validation_rules(self, validation_rules=None, schema=True, company_id=None, rules_id=None, endpoint=None):
+        data = {"data": validation_rules, "schema": schema}
+        company_id = company_id or self.company_id
+        endpoint = urljoin(
+            endpoint or self.base_endpoint,
+            f"workflows/rules/{company_id}/{rules_id}",
+        )
+        headers = self._get_headers()
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        return self._parse_response(
+            self.requests.put(endpoint, data=json.dumps(data), headers=headers)
+        )
+
     def create_file(self, file, filename=None, endpoint=None, headers=None):
         endpoint = urljoin(endpoint or self.base_endpoint, "fileupload/v2/multipart")
         headers = headers or {}

--- a/sypht/client.py
+++ b/sypht/client.py
@@ -258,6 +258,17 @@ class SyphtClient:
             self.requests.put(endpoint, data=json.dumps(data), headers=headers)
         )
 
+    def delete_validation_rules(self, company_id=None, rules_id=None, endpoint=None):
+        company_id = company_id or self.company_id
+        endpoint = urljoin(
+            endpoint or self.base_endpoint,
+            f"workflows/rules/{company_id}/{rules_id}",
+        )
+        headers = self._get_headers()
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        return self._parse_response(self.requests.delete(endpoint, headers=headers))
+
     def create_file(self, file, filename=None, endpoint=None, headers=None):
         endpoint = urljoin(endpoint or self.base_endpoint, "fileupload/v2/multipart")
         headers = headers or {}


### PR DESCRIPTION
Validation rules may now be externalised (stored in s3) and simply referenced in the workflow.json. The new get_validation_rules and set_validation_rules of this client provide an interface to obtain these rules from the s3 bucket